### PR TITLE
Add policy to allow consul cluster to query ASG for crons

### DIFF
--- a/elb.tf
+++ b/elb.tf
@@ -88,9 +88,15 @@ resource "aws_iam_role_policy_attachment" "ec2-read-only" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy" "consul_cron" {
+  name   = "${prefix}cron"
+  role   = "${aws_iam_role.consul.id}"
+  policy = "${file("${path.module}/policies/policy-consul_cron.json")}"
+}
+
 resource "aws_iam_instance_profile" "consul" {
   name       = "${var.prefix}iam-instance-profile"
-  roles      = ["${aws_iam_role.consul.name}"]
+  role       = "${aws_iam_role.consul.name}"
   depends_on = ["aws_iam_role.consul"]
 }
 

--- a/policies/policy-consul_cron.json
+++ b/policies/policy-consul_cron.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "ec2:DescribeInstanceAttribute",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is actually a redundant policy right now given that the other ReadOnly one already allows this action. ReadOnly will be scaled back soon, so this will protect that action.